### PR TITLE
Fix google chart plugin configuration persistence

### DIFF
--- a/src/gchart.js
+++ b/src/gchart.js
@@ -12,13 +12,14 @@ var root = module.exports = function(yasr){
 	var options = $.extend(true, {}, root.defaults);
 	var id = yasr.container.closest('[id]').attr('id');
 	
+	var chartWrapper = null;
 	var editor = null;
 	
 	var initEditor = function(callback) {
 		var google = require('google');
 		editor = new google.visualization.ChartEditor();
 		google.visualization.events.addListener(editor, 'ok', function(){
-				var chartWrapper, tmp;
+				var tmp;
 				chartWrapper = editor.getChartWrapper();
 				tmp = chartWrapper.getDataTable();
 				chartWrapper.setDataTable(null);
@@ -109,13 +110,12 @@ var root = module.exports = function(yasr){
 				//clear previous results (if any)
 				yasr.resultsContainer.empty();
 				var wrapperId = id + '_gchartWrapper';
-				var wrapper = null;
 
 				yasr.resultsContainer.append(
 					$('<button>', {class: 'openGchartBtn yasr_btn'})
 						.text('Chart Config')
 						.click(function() {
-							editor.openDialog(wrapper);
+							editor.openDialog(chartWrapper);
 						})
 				).append(
 					$('<div>', {id: wrapperId, class: 'gchartWrapper'})
@@ -150,30 +150,30 @@ var root = module.exports = function(yasr){
 
 				if (options.chartConfig && options.chartConfig.chartType) {
 					options.chartConfig.containerId = wrapperId;
-					wrapper = new google.visualization.ChartWrapper(options.chartConfig);
-					if (wrapper.getChartType() === "MotionChart" && options.motionChartState) {
-						wrapper.setOption("state", options.motionChartState);
-						google.visualization.events.addListener(wrapper, 'ready', function(){
+					chartWrapper = new google.visualization.ChartWrapper(options.chartConfig);
+					if (chartWrapper.getChartType() === "MotionChart" && options.motionChartState) {
+						chartWrapper.setOption("state", options.motionChartState);
+						google.visualization.events.addListener(chartWrapper, 'ready', function(){
 							var motionChart;
-							motionChart = wrapper.getChart();
+							motionChart = chartWrapper.getChart();
 							google.visualization.events.addListener(motionChart, 'statechange', function(){
 								options.motionChartState = motionChart.getState();
 								yasr.store();
 							});
 						});
 					}
-					wrapper.setDataTable(dataTable);
+					chartWrapper.setDataTable(dataTable);
 				} else {
-					wrapper = new google.visualization.ChartWrapper({
+					chartWrapper = new google.visualization.ChartWrapper({
 						chartType: 'Table',
 						dataTable: dataTable,
 						containerId: wrapperId
 					});
 				}
-				wrapper.setOption("width", options.width);
-				wrapper.setOption("height", options.height);
-				wrapper.draw();
-				google.visualization.events.addListener(wrapper, 'ready', yasr.updateHeader);
+				chartWrapper.setOption("width", options.width);
+				chartWrapper.setOption("height", options.height);
+				chartWrapper.draw();
+				google.visualization.events.addListener(chartWrapper, 'ready', yasr.updateHeader);
 			}
 			
 			if (!require('google') || !require('google').visualization || !editor) {


### PR DESCRIPTION
Nowadays, the chart wrapper returned by the editor seems not to be the same that it was given. For this plugin, this resulted in 'Chart Config' always starting from an initial configuration instead of the last edited state. 

This fixes the problem by saving the editor-returned chartWrapper variable for later reuse.
