### PR TITLE
Use protocol relative URL to get Google jsapi

### DIFF
--- a/src/gChartLoader.js
+++ b/src/gChartLoader.js
@@ -14,7 +14,7 @@ var loader = function() {
 			 * Existing libraries either ignore several browsers (e.g. jquery 2.x), or use ugly hacks (timeouts or something)
 			 * So, we use our own custom ugly hack (yes, timeouts)
 			 */
-			loadScript('http://google.com/jsapi', function() {
+			loadScript('//google.com/jsapi', function() {
 				loadingMain = false;
 				mod.emit('initDone');
 			});


### PR DESCRIPTION
Use a protocol relative URL to get Google jsapi to avoid 'Mixed content' errors in the browser when hosting YASGUI over HTTPS.
