### PR TITLE
Fix outputs buttons behavior

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,6 +125,11 @@ var YASR = function(parent, options, queryResults) {
     }
 
     if (outputToDraw) {
+      if (yasr.options.output !== outputToDraw) {
+        yasr.options.output = outputToDraw;
+        updateOutputSelectorButtons();
+      }
+
       $(yasr.resultsContainer).empty();
       yasr.emit("draw", yasr, yasr.plugins[outputToDraw]);
       yasr.plugins[outputToDraw].draw(yasr.options.pluginSettings[outputToDraw] || {});
@@ -137,9 +142,14 @@ var YASR = function(parent, options, queryResults) {
     }
   };
 
+  var updateOutputSelectorButtons = function() {
+      var buttons = yasr.header.find(".yasr_btnGroup .yasr_btn").removeClass("selected");
+      buttons.filter(".select_" + yasr.options.output).addClass("selected");
+  };
+
   var disableOutputs = function(outputs) {
     //first enable everything.
-    yasr.header.find(".yasr_btnGroup .yasr_btn").removeClass("disabled");
+    yasr.header.find(".yasr_btnGroup .yasr_btn").removeClass("disabled").removeAttr("disabled");
 
     //now disable the outputs passed as param
     outputs.forEach(function(outputName) {
@@ -147,7 +157,8 @@ var YASR = function(parent, options, queryResults) {
       if (module.exports.plugins[outputName] && module.exports.plugins[outputName].defaults) {
         disabledTitle = module.exports.plugins[outputName].defaults.disabledTitle;
       }
-      yasr.header.find(".yasr_btnGroup .select_" + outputName).addClass("disabled").attr("title", disabledTitle || "");
+      yasr.header.find(".yasr_btnGroup .select_" + outputName).addClass("disabled").attr("title", disabledTitle || "")
+        .attr("disabled", true);
     });
   };
   yasr.somethingDrawn = function() {


### PR DESCRIPTION
If the current output cannot handle the results the package selects an output that can handle them. But the outputs buttons are not updated and the selected button does not match to the selected output.

This updates the outputs buttons if the current output is not equal to the selected output.
Also adds the 'disabled' attribute to the unsupported outputs buttons to prevent their selection.