### PR TITLE
Removed extra spaces from CSV

### DIFF
--- a/src/bindingsToCsv.js
+++ b/src/bindingsToCsv.js
@@ -42,7 +42,7 @@ module.exports = function(result) {
       //and finally add quotes all around
       value = quote + value + quote;
     }
-    csvString += " " + value + " " + delimiter;
+    csvString += value + delimiter;
   };
 
   var needToQuoteString = function(value) {


### PR DESCRIPTION
Fix for #132 
This removes the extra spaces that were being added to CSVs. 
These spaces don't match what's given in [RFC 4180](https://tools.ietf.org/html/rfc4180) and cause the results to be displayed incorrectly in Excel.